### PR TITLE
correcting /etc/localtime stacktrace in latest mono release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Pull and run -- it's this simple.
 $> docker pull cturra/sonarr
 
 # run sonarr
-$> docker run --name=sonarr --restart=always --detach=true           \
-              --volume=/path/to/config/dir:/volumes/config/sonarr    \
-              --volume=/path/to/media/dir:/volumes/media             \
-              --volume=/path/to/download/dir:/data/downloads/complet \
+$> docker run --name=sonarr --restart=always --detach=true            \
+              --volume=/etc/localtime:/etc/localtime:ro               \
+              --volume=/path/to/config/dir:/volumes/config/sonarr     \
+              --volume=/path/to/media/dir:/volumes/media              \
+              --volume=/path/to/download/dir:/data/downloads/complete \
               --publish=8989:8989 cturra/sonarr
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - 8989:8989
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - /data/sonarr/config:/volumes/config/sonarr
       - /media/tv:/volumes/media
       - /data/downloads/complete:/data/downloads/complete

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,7 @@ function start_container() {
   $DOCKER run --name=${CONTAINER_NAME}                         \
               --restart=always                                 \
               --detach=true                                    \
+              --volume=/etc/localtime:/etc/localtime:ro        \
               --volume=${EXT_CONFIG_DIR}:${INT_CONFIG_DIR}     \
               --volume=${EXT_MEDIA_DIR}:${INT_MEDIA_DIR}       \
               --volume=${EXT_DOWNLOAD_DIR}:${INT_DOWNLOAD_DIR} \


### PR DESCRIPTION
mono started throwing the following traceback after upgrading to 4.8.1.0:

```
EPIC FAIL: System.IO.FileNotFoundException: Could not find file "/etc/localtime"
File name: '/etc/localtime'
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0025f] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) [0x00000] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)
  at System.IO.File.OpenRead (System.String path) [0x00000] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at System.TimeZoneInfo.FindSystemTimeZoneByFileName (System.String id, System.String filepath) [0x00011] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at System.TimeZoneInfo.CreateLocal () [0x000ed] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at System.TimeZoneInfo.get_Local () [0x0000c] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at System.TimeZoneInfo.GetDateTimeNowUtcOffsetFromUtc (System.DateTime time, System.Boolean& isAmbiguousLocalDst) [0x00000] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at System.DateTime.get_Now () [0x00008] in <dbb16e0bacdc4a0f87478e401bc29b6c>:0
  at NLog.Time.FastLocalTimeSource.get_FreshTime () [0x00000] in <595dc70423204ac199a723f0d6eec101>:0
  at NLog.Time.CachedTimeSource.get_Time () [0x00016] in <595dc70423204ac199a723f0d6eec101>:0
  at NLog.LogEventInfo..ctor () [0x0000c] in <595dc70423204ac199a723f0d6eec101>:0
  at NLog.LogEventInfo..ctor (NLog.LogLevel level, System.String loggerName, System.IFormatProvider formatProvider, System.String message, System.Object[] parameters, System.Exception exception) [0x00000] in <595dc70423204ac199a723f0d6eec101>:0
  at NLog.LogEventInfo.Create (NLog.LogLevel logLevel, System.String loggerName, System.Exception exception, System.IFormatProvider formatProvider, System.String message, System.Object[] parameters) [0x00000] in <595dc70423204ac199a723f0d6eec101>:0
  at NLog.Logger.WriteToTargets (NLog.LogLevel level, System.Exception ex, System.String message, System.Object[] args) [0x00021] in <595dc70423204ac199a723f0d6eec101>:0
  at NLog.Logger.Fatal (System.Exception exception, System.String message) [0x00008] in <595dc70423204ac199a723f0d6eec101>:0
  at NzbDrone.Console.ConsoleApp.Main (System.String[] args) [0x0007a] in M:\BuildAgent\work\b69c1fe19bfc2c38\src\NzbDrone.Console\ConsoleApp.cs:35
exception inside UnhandledException handler: Could not find file "/etc/localtime"
```

to work around this, lets mount /etc/localtime in (r)ead(o)nly from the local system.