### PR TITLE
upgrading from xenial (16.04) to bionic beaver (18.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# setup and install mono (key: D3D831EF) / sonarr (key: FDA5DFFC)
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D3D831EF                                       \
- && echo "deb http://download.mono-project.com/repo/debian wheezy main" > /etc/apt/sources.list.d/mono.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC                                       \
- && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list                      \
+# prep, config and install mono and sonarr
+RUN apt-get -q update      \
+ && apt-get -y install gpg \
+ # setup mono (key: D3D831EF) / sonarr (key: FDA5DFFC) repos
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D3D831EF                                              \
+ && echo "deb http://download.mono-project.com/repo/debian stable-bionic main" > /etc/apt/sources.list.d/mono.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC                                              \
+ && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list                             \
+ # install mono and sonarr
  && apt-get -q update            \
  && apt-get -y install mediainfo \
                        nzbdrone  \

--- a/README.md
+++ b/README.md
@@ -14,22 +14,25 @@ Pull and run -- it's this simple.
 $> docker pull cturra/sonarr
 
 # run sonarr
-$> docker run --name=sonarr --restart=always --detach=true            \
+$> docker run --name=sonarr                                           \
+              --restart=always                                        \
+              --detach=true                                           \
+              --publish=8989:8989                                     \
               --volume=/etc/localtime:/etc/localtime:ro               \
               --volume=/path/to/config/dir:/volumes/config/sonarr     \
               --volume=/path/to/media/dir:/volumes/media              \
               --volume=/path/to/download/dir:/data/downloads/complete \
-              --publish=8989:8989 cturra/sonarr
+              cturra/sonarr
 ```
 
 
-Building and Running with Docker Compose
+Build and Running with Docker Compose
 ---
 Using the `docker-compose.yml` file included in this git repo, you can build
 the container yourself (should you choose to).
 
 ```
-# buid sonarr
+# build sonarr
 $> docker-compose build sonarr
 
 # run sonarr


### PR DESCRIPTION
minimal updates required. just needed to pre-fetch gpg in support of running the `apt-key` command to fetch repo keys.