### PR TITLE
Buildfix: use fullform apt keys

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,7 +1,8 @@
 The following awesome folks have contributed ideas,
-bug reports and code to this radarr docker project:
+bug reports and code to this sonarr docker project:
 
- - Chris Turra  => https://github.com/cturra
+ - Chris Turra    => https://github.com/cturra
+ - Graham Greving => https://github.com/gramasaurous
 
 
 Thanks for your contributions!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:18.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
-# prep, config and install mono and sonarr
+# prep/config mono and sonarr
 RUN apt-get -q update      \
  && apt-get -y --no-install-recommends install dirmngr   \
                                                gpg       \
                                                gpg-agent
 
-# setup mono (key: D3D831EF) / sonarr (key: FDA5DFFC) repos
+# fetch/install/setup for mono (key: D3D831EF) / sonarr (key: FDA5DFFC)
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF            \
  && echo "deb http://download.mono-project.com/repo/debian stable-bionic main" > /etc/apt/sources.list.d/mono.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -q update      \
  && apt-get -y install gpg \
  # setup mono (key: D3D831EF) / sonarr (key: FDA5DFFC) repos
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D3D831EF                                              \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF              \
  && echo "deb http://download.mono-project.com/repo/debian stable-bionic main" > /etc/apt/sources.list.d/mono.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC                                              \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493            \
  && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list                             \
  # install mono and sonarr
  && apt-get -q update            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,24 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # prep, config and install mono and sonarr
 RUN apt-get -q update      \
- && apt-get -y install gpg \
- # setup mono (key: D3D831EF) / sonarr (key: FDA5DFFC) repos
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF              \
+ && apt-get -y --no-install-recommends install dirmngr   \
+                                               gpg       \
+                                               gpg-agent
+
+# setup mono (key: D3D831EF) / sonarr (key: FDA5DFFC) repos
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF            \
  && echo "deb http://download.mono-project.com/repo/debian stable-bionic main" > /etc/apt/sources.list.d/mono.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493            \
- && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list                             \
- # install mono and sonarr
- && apt-get -q update            \
- && apt-get -y install mediainfo \
-                       nzbdrone  \
- && rm -rf /var/lib/apt/lists/*
+ && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list
+
+# install mono and sonarr
+RUN apt-get -q update                                    \
+ && apt-get -y --no-install-recommends install mediainfo \
+                                               nzbdrone
+
+# clean up after apt
+RUN apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # expose sonarr non-ssl and ssl tcp ports
 EXPOSE 8989/tcp 9898/tcp


### PR DESCRIPTION
Fix for #3, use full-form GPG keys for sonarr, mono apt packages - as noted here: https://forums.sonarr.tv/t/ubuntu-apt-repo-key-collision-security-concern/20285

Diff:
```
gg@frank:~/dev/gramasaurous/docker-sonarr$ git diff
diff --git a/Dockerfile b/Dockerfile
index f127f30..a059827 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -q update      \
  && apt-get -y install gpg \
  # setup mono (key: D3D831EF) / sonarr (key: FDA5DFFC) repos
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D3D831EF                                              \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF              \
  && echo "deb http://download.mono-project.com/repo/debian stable-bionic main" > /etc/apt/sources.list.d/mono.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC                                              \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493            \
  && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list                             \
  # install mono and sonarr
  && apt-get -q update  
```
Build log (with `--no-cache`)
```
gg@frank:~/dev/gramasaurous/docker-sonarr$ ./build.sh 
Sending build context to Docker daemon  129.5kB
Step 1/6 : FROM ubuntu:18.04
18.04: Pulling from library/ubuntu
Digest: sha256:250cc6f3f3ffc5cdaa9d8f4946ac79821aafb4d3afc93928f0de9336eba21aa4
Status: Image is up to date for ubuntu:18.04
 ---> 549b9b86cb8d
Step 2/6 : ENV DEBIAN_FRONTEND noninteractive
 ---> Running in 4ed48a01bd89
Removing intermediate container 4ed48a01bd89
 ---> bfbd92f457f8
Step 3/6 : RUN apt-get -q update       && apt-get -y install gpg  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF               && echo "deb http://download.mono-project.com/repo/debian stable-bionic main" > /etc/apt/sources.list.d/mono.list  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493             && echo "deb http://apt.sonarr.tv/ master main" > /etc/apt/sources.list.d/sonarr.list                              && apt-get -q update             && apt-get -y install mediainfo                        nzbdrone   && rm -rf /var/lib/apt/lists/*
[...]
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.9mRZafzTCZ/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
gpg: key A6A19B38D3D831EF: 2 signatures not checked due to missing keys
gpg: key A6A19B38D3D831EF: public key "Xamarin Public Jenkins (auto-signing) <releng@xamarin.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.mduDFEsfxe/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493
gpg: key EBFF6B99D9B78493: public key "NzbDrone <contact@nzbdrone.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
[...]
Removing intermediate container e31eb510d12a
 ---> 5594718f6c0a
Step 4/6 : EXPOSE 8989/tcp 9898/tcp
 ---> Running in 16ff34337bc4
Removing intermediate container 16ff34337bc4
 ---> d87a5989684a
Step 5/6 : COPY assets/scripts/startup.sh /opt/startup.sh
 ---> a8075be47e97
Step 6/6 : ENTRYPOINT [ "/bin/bash", "/opt/startup.sh" ]
 ---> Running in 58d70798af27
Removing intermediate container 58d70798af27
 ---> fac1dc7bc8ef
Successfully built fac1dc7bc8ef
Successfully tagged cturra/sonarr:latest

```

Two notes from this build log:

- seeing error:
    `debconf: delaying package configuration, since apt-utils is not installed`
    not sure if this needs to be addressed
- seeing error:
    `Warning: apt-key output should not be parsed (stdout is not a terminal)`
    all fixes[1] I see for this refer to setting an "allow unsafe operations" flag in apt preferences, which seems... less than ideal

[1] https://stackoverflow.com/questions/48162574/how-to-circumvent-apt-key-output-should-not-be-parsed